### PR TITLE
Add clarification for Tasmota 15 coordinator firmware flashing process

### DIFF
--- a/_posts/2024-01-10-flashing-tasmota-on-a-sonoff-zigbee-bridge.md
+++ b/_posts/2024-01-10-flashing-tasmota-on-a-sonoff-zigbee-bridge.md
@@ -191,6 +191,14 @@ File System:
 
 ![](/images/{{ page.id }}/tasmota-file-system.png)
 
+> #### Note for Tasmota 15
+> The coordinator firmware bundled with the tasmota32-zbbrdgpro.factory.bin
+image of Tasmota 15 is outdated and will cause errors during flashing. Instead of
+using the included 20220219 version, download the updated firmware from
+[SonoffZBPro_coord_20240710.hex](https://github.com/arendst/Tasmota/blob/v15.0.1/tools/fw_SonoffZigbeeBridgePro_cc2652/SonoffZBPro_coord_20240710.hex)
+and upload the file via the Manage File System function. Once uploaded, continue
+with the steps below using the newly updated firmware.
+
 The flashing procedure is carried out from the `Berry Scripting` console. Go to
 Consoles -> Berry Scripting.
 


### PR DESCRIPTION
Hey Stephen,

I hope you are doing well. I used your excellent post on flashing Tasmota onto the Sonoff Zigbee Bridge Pro. Everything worked fine and by now I have a working Zigbee Bridge in my Home Assistant. There was just one part that drove me crazy: The flashing process of the coordinator firmware. 

The problem seems to be that the 20220219 version of the coordinator firmware does not work properly with Tasmota 15 although it is automatically coming with it. It took me some time to figure out that this outdated version of the coordinator firmware does not work but only the 20240710 version will lead to success. 

I created a small PR to add a note so that people using Tasmota 15 will also succeed following your guide. I hope this is ok. Please feel free to merge or ignore this as you please. 

Thanks and have a great day,
Fabian